### PR TITLE
Add optional chaining

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,9 @@ export default new Transformer({
     const { contents } = await config.getConfig(["config.json"]);
 
     // find archie files to insert
-    const confaml = contents.fetch.filter(
-      d => !d.hasOwnProperty("sheetId") && d.id.length > 0 && d.output.length > 0
+    const confaml = contents?.fetch?.filter(
+      (d) =>
+        !d.hasOwnProperty("sheetId") && d.id.length > 0 && d.output.length > 0
     );
 
     let archie = null;


### PR DESCRIPTION
#### What's this PR do?

Adds optional chaining to `contents.fetch.filter` so the transformer doesn't fail when there is no `fetch` property.

#### Are there any relevant screenshots?

#### Why are we doing this? How does it help us?

#### How should this be manually tested?

#### Are there any smells or added technical debt to note?

#### What are relevant issues or links?

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
