### PR TITLE
Prefer hasOwn over hasOwnProperty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michigandaily/parcel-transformer-nunjucks",
   "repository": "https://github.com/MichiganDaily/parcel-transformer-nunjucks",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Naitian Zhou"
   },
@@ -16,9 +16,9 @@
     "parcel": "2.x"
   },
   "dependencies": {
-    "@parcel/core": "~2.6.0",
-    "@parcel/plugin": "~2.6.0",
+    "@parcel/core": "~2.7.0",
+    "@parcel/plugin": "~2.7.0",
     "nunjucks": "^3.2.3",
-    "parcel": "~2.6.0"
+    "parcel": "~2.7.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default new Transformer({
     // find archie files to insert
     let archie = null;
     const confaml = contents?.fetch?.filter(
-      (d) => !d.hasOwnProperty("sheetId")
+      (d) => !Object.hasOwn(d, "sheetId")
     );
     if (confaml?.length === 1) {
       archie = (await config.getConfig([confaml[0].output]))?.contents;


### PR DESCRIPTION
#### What's this PR do?

From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn):

> Note: Object.hasOwn() is intended as a replacement for [Object.hasOwnProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty).

#### Are there any relevant screenshots?

#### Why are we doing this? How does it help us?

#### How should this be manually tested?

#### Are there any smells or added technical debt to note?

#### What are relevant issues or links?

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
